### PR TITLE
Change major version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,6 @@ Download
 
 ```kotlin
 dependencies {
-    implementation("com.michaelpardo:oolong:1.1.0-SNAPSHOT")
+    implementation("com.michaelpardo:oolong:2.0.0-SNAPSHOT")
 }
 ```

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.michaelpardo
-VERSION_NAME=1.1.0-SNAPSHOT
+VERSION_NAME=2.0.0-SNAPSHOT
 POM_DESCRIPTION=MVU for Kotlin Multiplatform
 
 POM_URL=https://github.com/pardom/oolong/


### PR DESCRIPTION
Semantic versioning reserves major version changes for " when you make
incompatible API changes". The changes in Oolong since version 1.0.0
make it incompatible with 1.0.0 APIs.